### PR TITLE
CDMS-713: Use the provided proxy if running in CDP

### DIFF
--- a/wdio.browserstack.conf.js
+++ b/wdio.browserstack.conf.js
@@ -6,13 +6,13 @@ import { bootstrap } from 'global-agent'
  * Enable webdriver.io to use the outbound proxy.
  * This is required for the test suite to be able to talk to BrowserStack.
  */
-if (process.env.HTTP_PROXY) {
+if (process.env.CDP_HTTP_PROXY) {
   const dispatcher = new ProxyAgent({
-    uri: process.env.HTTP_PROXY
+    uri: 'http://localhost:3128'
   })
   setGlobalDispatcher(dispatcher)
   bootstrap()
-  global.GLOBAL_AGENT.HTTP_PROXY = process.env.HTTP_PROXY
+  global.GLOBAL_AGENT.HTTP_PROXY = 'http://localhost:3128'
 }
 
 const oneMinute = 60 * 1000


### PR DESCRIPTION
The BrowserStack Local binary is currently failing to download for some reason, possibly proxy related.

I don't think the proxy is being used properly, so this updates the browserstack config file to check if the CDP_HTTP_PROXY variable is set (are we running in CDP) and then configures it to use the provided localhost proxy server.