### PR TITLE
CDMS-713: Pre-download the BrowserStackLocal binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ WORKDIR /app
 COPY ["package.json", "package-lock.json", "./"]
 RUN npm install
 
+ADD https://dnd2hcwqjlbad.cloudfront.net/binaries/release/latest_unzip/BrowserStackLocal-linux-x64 /root/.browserstack/BrowserStackLocal
+RUN chmod +x /root/.browserstack/BrowserStackLocal
+
 COPY . .
 
 ENTRYPOINT [ "./entrypoint.sh" ]

--- a/wdio.browserstack.conf.js
+++ b/wdio.browserstack.conf.js
@@ -85,7 +85,7 @@ export const config = {
       {
         testObservability: true, // Disable if you do not want to use the browserstack test observer functionality
         testObservabilityOptions: {
-          user: process.env.BROWSERSTACK_USER,
+          user: process.env.BROWSERSTACK_USERNAME,
           key: process.env.BROWSERSTACK_KEY,
           projectName: 'trade-imports-frontend-tests',
           buildName: `trade-imports-frontend-tests-${process.env.ENVIRONMENT}`
@@ -94,6 +94,8 @@ export const config = {
         forceLocal: false,
         browserstackLocal: true,
         opts: {
+          // This is where BrowserStack usually downloads to, but by specifying the binarypath it skips trying to download again
+          binarypath: '/root/.browserstack/BrowserStackLocal',
           proxyHost: 'localhost',
           proxyPort: 3128
         }


### PR DESCRIPTION
Something funky is going on with the proxy. 
This is an attempt to download the binary at build time to avoid needing to do it in CDP-land.