### PR TITLE
CDMS-713: Re-add modules and tweak settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,8 @@
         "@wdio/spec-reporter": "9.12.2",
         "@wdio/visual-service": "6.3.3",
         "allure-commandline": "2.33.0",
+        "dotenv": "16.5.0",
+        "esm-module-alias": "2.2.1",
         "global-agent": "3.0.0",
         "undici": "7.6.0"
       },
@@ -4413,6 +4415,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/esm-module-alias": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/esm-module-alias/-/esm-module-alias-2.2.1.tgz",
+      "integrity": "sha512-CmxoWJb4ShzOQEHc5MBIgp7BUYSiyZkvUzGtJxQlCUZhLXJ/teO7LSyZa9gzPpM5HOarj14GW4DxRuTuCliV1w==",
+      "license": "MIT"
     },
     "node_modules/espree": {
       "version": "9.6.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "@wdio/spec-reporter": "9.12.2",
     "@wdio/visual-service": "6.3.3",
     "allure-commandline": "2.33.0",
+    "dotenv": "16.5.0",
+    "esm-module-alias": "2.2.1",
     "global-agent": "3.0.0",
     "undici": "7.6.0"
   },

--- a/wdio.browserstack.conf.js
+++ b/wdio.browserstack.conf.js
@@ -103,16 +103,20 @@ export const config = {
     ]
   ],
 
-  execArgv: debug ? ['--inspect'] : [],
+  execArgv: [
+    '--loader',
+    'esm-module-alias/loader',
+    ...(debug ? ['--inspect'] : [])
+  ],
 
   logLevel: debug ? 'debug' : 'info',
 
   // Number of failures before the test suite bails.
   bail: 0,
-  waitforTimeout: 1000,
+  waitforTimeout: 3000,
   waitforInterval: 300,
-  connectionRetryTimeout: 12000,
-  connectionRetryCount: 1,
+  connectionRetryTimeout: 60000,
+  connectionRetryCount: 3,
 
   framework: 'mocha',
 


### PR DESCRIPTION
Now we are able to contact BrowserStack, this PR adds in the modules that were removed earlier (to match CDPs config) and increases the timeouts, because BrowserStack is notoriously flaky.