### PR TITLE
Add lastMonthFilter() so that tests work with data created today (for…

### DIFF
--- a/test/specs/reporting.e2e.js
+++ b/test/specs/reporting.e2e.js
@@ -86,6 +86,7 @@ describe('Reporting page', () => {
   })
 
   it('Should show CSV download links for No matches and Manual releases and they are clickable', async () => {
+    await ReportingPage.lastMonthFilter()
     await ReportingPage.openSummaryTab()
 
     const noMatchesVisible =
@@ -320,6 +321,7 @@ describe('Reporting page', () => {
   })
 
   it('Should validate percentage calculations across Summary tiles', async () => {
+    await ReportingPage.lastMonthFilter()
     await ReportingPage.openSummaryTab()
 
     const matchesPct = await ReportingPage.getSummaryMatchesPercentage()


### PR DESCRIPTION
… clean local envs)

Added last month filter before opening the summary tab in two test cases to ensure accurate data retrieval.