### PR TITLE
CDMS-1479: Fix remaining imports, tidy up logs and clean up failed file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ Dockerfile
 .git
 .github
 .husky
+FAILED

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "components": "test/components"
   },
   "scripts": {
-    "clean": "rm -rf allure-results && rm -rf allure-report && rm -rf reports",
+    "clean": "rm -rf allure-results && rm -rf allure-report && rm -rf reports && rm -f FAILED",
     "test:accessibility": "npm run clean && wdio run wdio.local.conf.js --spec test/specs/accessibility.e2e.js",
     "test:cdp:browserstack": "npm run clean && wdio run wdio.browserstack.cdp.conf.js",
     "test:local": "npm run clean && wdio run wdio.local.conf.js",

--- a/test/utils/ipaffsMessageHandler.js
+++ b/test/utils/ipaffsMessageHandler.js
@@ -5,7 +5,7 @@ import { ProxyAgent } from 'proxy-agent'
 import { readFile } from 'fs/promises'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import './logger'
+import './logger.js'
 
 export async function sendIpaffMessageFromFile(relativePath) {
   globalThis.testLogger.info({

--- a/test/utils/processorClient.js
+++ b/test/utils/processorClient.js
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { readFile } from 'fs/promises'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import './logger'
+import './logger.js'
 
 const baseUrl =
   process.env.BASE_URL_TRADE_IMPORTS_PROCESSOR ??

--- a/wdio.browserstack.conf.js
+++ b/wdio.browserstack.conf.js
@@ -45,7 +45,7 @@ export const config = {
     ...(debug ? ['--inspect'] : [])
   ],
 
-  logLevel: debug ? 'debug' : 'info',
+  logLevel: debug ? 'debug' : 'warn',
 
   bail: 0,
   waitforTimeout: 6000,


### PR DESCRIPTION
A couple of files were missing the .js extension.
The logs in the runner output a lot of text that was not useful.